### PR TITLE
chore: upgrade native SDK to 3.6.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agora-electron-sdk",
-  "version": "3.6.1-rc.9-build.817",
+  "version": "3.6.1-rc.10-build.914",
   "description": "agora-electron-sdk",
   "main": "js/AgoraSdk.js",
   "types": "types/AgoraSdk.d.ts",
@@ -74,8 +74,8 @@
     "url": "git+https://github.com/AgoraIO-Community/Agora-RTC-SDK-for-Electron.git"
   },
   "agora_electron": {
-    "lib_sdk_win": "https://download.agora.io/sdk/release/Agora_Native_SDK_for_Windows_v3.6.1.9_FULL_20220813_8791_227246.zip",
-    "lib_sdk_mac": "https://download.agora.io/sdk/release/Agora_Native_SDK_for_Mac_v3.6.1.8_FULL_20220726_2811_222960.zip"
+    "lib_sdk_win": "http://192.168.99.149:8086/v3.6.1.10/AgoraSDK/Windows/testing/Agora_Native_SDK_for_Windows_v3.6.1.10_FULL_20220907_8903_232248.zip",
+    "lib_sdk_mac": "http://192.168.99.149:8086/v3.6.1.10/AgoraSDK/Mac/Agora_Native_SDK_for_Mac_v3.6.1.10_FULL_20220908_2958_232448.zip"
   },
   "keywords": [
     "electron",


### PR DESCRIPTION
chore: upgrade native SDK to 3.6.1.10