### PR TITLE
chore: upgrade native SDK to 3.6.1.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agora-electron-sdk",
-  "version": "3.6.1-rc.16-wps.424",
+  "version": "3.6.1-rc.17-build.515",
   "description": "agora-electron-sdk",
   "main": "js/AgoraSdk.js",
   "types": "types/AgoraSdk.d.ts",
@@ -74,7 +74,7 @@
     "url": "git+https://github.com/AgoraIO-Community/Agora-RTC-SDK-for-Electron.git"
   },
   "agora_electron": {
-    "lib_sdk_win": "https://download.agora.io/sdk/release/Agora_Native_SDK_for_Windows_v3.6.1.16_FULL_20230420_9373_262051.zip",
+    "lib_sdk_win": "https://download.agora.io/staging/Agora_Native_SDK_for_Windows_v3.6.1.17_FULL_20230511_9390_263972.zip",
     "lib_sdk_mac": "https://download.agora.io/sdk/release/Agora_Native_SDK_for_Mac_v3.6.1.16_FULL_20230417_3288_261803.zip"
   },
   "keywords": [

--- a/ts/Api/native_type.ts
+++ b/ts/Api/native_type.ts
@@ -36,7 +36,7 @@ export interface SIZE {
  * @note The default image is in the RGBA format. If you need to use another format, you need to convert the image on
  * your own.
  */
- export interface ThumbImageBuffer {
+export interface ThumbImageBuffer {
   /**
    * The buffer of the thumbnail or icon.
    */
@@ -3087,6 +3087,15 @@ export enum LOCAL_VIDEO_STREAM_ERROR {
   /** 21: The screen capture fails. */
   LOCAL_VIDEO_STREAM_ERROR_SCREEN_CAPTURE_FAILURE = 21,
   LOCAL_VIDEO_STREAM_ERROR_SCREEN_CAPTURE_NO_PERMISSION = 22,
+  /** 23: (Windows only The screen capture fails with invalid parameters. */
+  LOCAL_VIDEO_STREAM_ERROR_SCREEN_CAPTURE_INVALID_PARAMETERS = 23,
+  /**
+   * 24: (Windows only The screen capture auto fallback to GDI
+   * When this error occurs, it means that the screen sharing failed to filter the specified window list of the user. Mowever, the sereen sharing is still ongoing.
+   *
+   * @since v3.6.1.17
+   */
+  LOCAL_VIDEO_STREAM_ERROR_SCREEN_CAPTURE_AUTO_FALLBACK = 24,
 }
 
 /** Local audio state types.
@@ -4762,7 +4771,7 @@ export interface NodeRtcEngine {
   videoSourceSetScreenCaptureScenario(
     type: SCREEN_SCENARIO_TYPE
   ): number;
-  
+
   isFeatureSupported(
     type: FeatureType
   ): boolean;
@@ -4986,7 +4995,7 @@ export interface NodeRtcChannel {
   sendStreamMessageWithArrayBuffer(
     streamId: number,
     buffer: UInt8ArrayBuffer
-  ): number 
+  ): number
 }
 
 /** Audio codec profile types. The default value is LC_ACC. */
@@ -5107,9 +5116,9 @@ export enum LOCAL_PROXY_MODE {
 }
 
 export interface UploadServerInfo {
-  serverDomain:string;
+  serverDomain: string;
 
-  serverPath:string;
+  serverPath: string;
 
   serverPort: number;
 


### PR DESCRIPTION
chore: upgrade native SDK to 3.6.1.17