### PR TITLE
[AUTO] Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "yuv-canvas": "1.2.6"
   },
   "agora_electron": {
-    "iris_sdk_win": "https://download.agora.io/sdk/release/iris_4.2.3.2-dev.1_DCG_Windows_Video_20231103_0217.zip",
-    "iris_sdk_mac": "https://download.agora.io/sdk/release/iris_4.2.3-build.4_DCG_Mac_Video_20231019_0355.zip"
+    "iris_sdk_win": "https://download.agora.io/sdk/release/iris_4.2.3.2-build.1_DCG_Windows_Video_20231115_0251.zip",
+    "iris_sdk_mac": "https://download.agora.io/sdk/release/iris_4.2.3.2-build.1_DCG_Mac_Video_20231115_0251.zip"
   }
 }


### PR DESCRIPTION
Dependencies content: 

'io.agora.rtc:iris-rtc:4.2.3.2-build.1'
None
None
'AgoraIrisRTC_iOS', '4.2.3.2-build.1'
None
https://download.agora.io/sdk/release/iris_4.2.3.2-build.1_DCG_Windows_Video_20231115_0251.zip
https://download.agora.io/sdk/release/iris_4.2.3.2-build.1_DCG_Mac_Video_20231115_0251.zip
'AgoraIrisRTC_macOS', '4.2.3.2-build.1'
None