### PR TITLE
[AUTO] Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "yuv-canvas": "1.2.6"
   },
   "agora_electron": {
-    "iris_sdk_win": "https://download.agora.io/sdk/release/iris_4.3.0-dev.3_DCG_Windows_Video_20231130_1137.zip",
-    "iris_sdk_mac": "https://download.agora.io/sdk/release/iris_4.3.0-dev.3_DCG_Mac_Video_20231130_1137.zip"
+    "iris_sdk_win": "https://download.agora.io/sdk/release/iris_4.3.0-dev.6_DCG_Windows_Video_20231205_1200.zip",
+    "iris_sdk_mac": "https://download.agora.io/sdk/release/iris_4.3.0-dev.6_DCG_Mac_Video_20231205_1200.zip"
   }
 }


### PR DESCRIPTION
Dependencies content: 

'io.agora.rtc:iris-rtc:4.3.0-dev.6'
'io.agora.rtc:agora-full-preview:4.3.0-dev.6'
'io.agora.rtc:full-screen-sharing-special:4.3.0-dev.6'
'AgoraIrisRTC_iOS', '4.3.0-dev.6'
'AgoraRtcEngine_iOS_Preview', '4.3.0-dev.6'
https://download.agora.io/sdk/release/iris_4.3.0-dev.6_DCG_Windows_Video_20231205_1200.zip
https://download.agora.io/sdk/release/iris_4.3.0-dev.6_DCG_Mac_Video_20231205_1200.zip
None
'AgoraRtcEngine_macOS_Preview', '4.3.0-dev.6'