### PR TITLE
chore: update iris sdk url to 4.2.2.144

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
   "engines": {
     "node": ">= 14.0.0"
   },
-  "packageManager": "^yarn@1.22.15",
   "jest": {
     "modulePathIgnorePatterns": [
       "<rootDir>/example/node_modules",
@@ -138,7 +137,7 @@
     "yuv-canvas": "1.2.6"
   },
   "agora_electron": {
-    "iris_sdk_win": "https://download.agora.io/sdk/release/iris_4.2.2.143-build.1_DCG_Windows_Video_20240521_0544.zip",
+    "iris_sdk_win": "https://download.agora.io/sdk/release/iris_4.2.2.144-build.1_DCG_Windows_Video_20241114_0221.zip",
     "iris_sdk_mac": "https://download.agora.io/sdk/release/iris_4.2.2.136-build.1_DCG_Mac_Video_20230922_0351.zip"
   }
 }


### PR DESCRIPTION
update iris sdk url to 4.2.2.144