### PR TITLE
chore: ignore legacy lefthook hash false positive in gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -18,4 +18,9 @@ regex = '''"[0-9a-f]{32}"'''
 id = "hashed-password-md5"
 description = "MD5 Password"
 regex = '''['\ "=]+[0-9a-f]{32}['\ "\n]+'''
+[rules.allowlist]
+description = "ignore legacy lefthook version hash comments"
+paths = [
+    '''^\.husky/prepare-commit-msg$''',
+]
 # ----- END MD5 Password -----


### PR DESCRIPTION
## Summary
- add a rule-scoped allowlist under `hashed-password-md5`
- ignore the legacy `.husky/prepare-commit-msg` lefthook version hash comment that triggers a false positive
- keep the rest of the MD5 scanning behavior unchanged

## Verification
- `git diff --check`
- `gitleaks detect --config .gitleaks.toml --source . --no-banner --report-format json --report-path /tmp/gitleaks-worktree-verify.json`
- confirmed the `.husky/prepare-commit-msg:35` false positive is no longer reported and the total findings drop from 25 to 24
