### PR TITLE
fix: normalize preview version for Terra

### DIFF
--- a/scripts/internal/dep.sh
+++ b/scripts/internal/dep.sh
@@ -17,6 +17,7 @@ IRIS_MAC_DEPENDENCIES=$(echo "$INPUT" | jq -r '.[] | select(.platform == "macOS"
 WINDOWS_DEPENDENCIES=$(echo "$INPUT" | jq -r '.[] | select(.platform == "Windows") | .cdn[]')
 IRIS_WINDOWS_DEPENDENCIES=$(echo "$INPUT" | jq -r '.[] | select(.platform == "Windows") | .iris_cdn[]')
 DEP_VERSION=$(echo "$INPUT" | jq -r '.[] | select(.platform == "Windows") | .version')
+TERRA_SDK_VERSION="${DEP_VERSION%-build.*}"
 
 if [ -z "$MAC_DEPENDENCIES" ]; then
   echo "No mac native dependencies need to change."
@@ -63,8 +64,8 @@ if [ -z "$DEP_VERSION" ]; then
   echo "can not find dependencies version."
 else
   echo "update dependencies version to $TERRA_CONFIG_PATH1"
-  sed 's|sdkVersion: \(.*\)|sdkVersion: '$DEP_VERSION'|g' $TERRA_CONFIG_PATH1 > tmp
+  sed 's|sdkVersion: \(.*\)|sdkVersion: '$TERRA_SDK_VERSION'|g' $TERRA_CONFIG_PATH1 > tmp
   mv tmp $TERRA_CONFIG_PATH1
-  sed 's|sdkVersion: \(.*\)|sdkVersion: '$DEP_VERSION'|g' $TERRA_CONFIG_PATH2 > tmp
+  sed 's|sdkVersion: \(.*\)|sdkVersion: '$TERRA_SDK_VERSION'|g' $TERRA_CONFIG_PATH2 > tmp
   mv tmp $TERRA_CONFIG_PATH2
 fi


### PR DESCRIPTION
## Summary
- strip the Preview `-build.*` suffix only when writing Terra `sdkVersion`
- keep the full dependency version and CDN URLs unchanged

## Context
Rehoboam dependency generation for ASS-2998 resolved Native `4.5.3.4-build.1`, while the extracted header directory is `rtc_4.5.3.4`. Terra consequently received empty header paths.

## Verification
- end-to-end dep.sh fixture: `4.5.3.4-build.1 -> 4.5.3.4`
- end-to-end dep.sh fixture: `4.5.3.123 -> 4.5.3.123`
- verified all four Native/Iris URLs remain unchanged by normalization
- `bash -n scripts/internal/dep.sh`
- `git diff --check`

Baseline full Jest requires the locally built native addon; baseline full typecheck requires the separately installed example dependencies.