### PR TITLE
fix(ci): allow Electron Windows packages in CodeSign

### DIFF
--- a/ci/build/build_windows.groovy
+++ b/ci/build/build_windows.groovy
@@ -53,6 +53,7 @@ def doPublish(buildVariables) {
     }
     def codesignResult = build(job: 'CodeSign', parameters: [
         text(name: 'PACKAGE_URLS', value: codesignUrls.join('\n')),
+        string(name: 'SIGN_PACKAGE_WHITELIST', value: '*_windows_*.zip'),
         string(name: 'SIGN_FILE_WHITELIST', value: '*.node'),
     ], propagate: false)
     if (!codesignResult || codesignResult.result != 'SUCCESS') {


### PR DESCRIPTION
## Summary
- pass the Electron Windows archive pattern to the hardened CodeSign job
- preserve the existing *.node file whitelist

## Why
Official release build #781 produced both Windows archives, but CodeSign #836 and #837 rejected them because the new default package whitelist only covers Native SDK and Wayang archives.

## Validation
- ia32 and x64 artifact names both match *_windows_*.zip
- git diff --check
- one shared call site covers both Windows release legs