### PR TITLE
fix: normalize preview version for Terra on special/4.2

### DIFF
--- a/scripts/internal/dep.sh
+++ b/scripts/internal/dep.sh
@@ -17,6 +17,7 @@ IRIS_MAC_DEPENDENCIES=$(echo "$INPUT" | jq -r '.[] | select(.platform == "macOS"
 WINDOWS_DEPENDENCIES=$(echo "$INPUT" | jq -r '.[] | select(.platform == "Windows") | .cdn[]')
 IRIS_WINDOWS_DEPENDENCIES=$(echo "$INPUT" | jq -r '.[] | select(.platform == "Windows") | .iris_cdn[]')
 DEP_VERSION=$(echo "$INPUT" | jq -r '.[] | select(.platform == "Windows") | .version')
+TERRA_SDK_VERSION="${DEP_VERSION%-build.*}"
 
 if [ -z "$MAC_DEPENDENCIES" ]; then
   echo "No mac native dependencies need to change."
@@ -63,8 +64,8 @@ if [ -z "$DEP_VERSION" ]; then
   echo "can not find dependencies version."
 else
   echo "update dependencies version to $TERRA_CONFIG_PATH1"
-  sed 's|sdkVersion: \(.*\)|sdkVersion: '$DEP_VERSION'|g' $TERRA_CONFIG_PATH1 > tmp
+  sed 's|sdkVersion: \(.*\)|sdkVersion: '$TERRA_SDK_VERSION'|g' $TERRA_CONFIG_PATH1 > tmp
   mv tmp $TERRA_CONFIG_PATH1
-  sed 's|sdkVersion: \(.*\)|sdkVersion: '$DEP_VERSION'|g' $TERRA_CONFIG_PATH2 > tmp
+  sed 's|sdkVersion: \(.*\)|sdkVersion: '$TERRA_SDK_VERSION'|g' $TERRA_CONFIG_PATH2 > tmp
   mv tmp $TERRA_CONFIG_PATH2
 fi


### PR DESCRIPTION
## Summary

Backport the Preview-version normalization from #1458 to the maintained `special/4.2` line. Electron dependency archives keep `4.2.7.143-build.4`, while Terra resolves the extracted header root as `rtc_4.2.7.143`.

## Context

- Jira: ASS-2910
- Failed dependency run: 33630941093
- First causal failure: Terra received no valid header identity from `4.2.7.143-build.4`
- Stale dependency PR #1462 must not be merged before regeneration

## Validation

- `bash -n scripts/internal/dep.sh`
- Executed `dep.sh` against the four selected build.4 Native/Iris URLs in a temporary fixture
- Asserted all four dependency fields retain the exact build.4 URLs
- Asserted both Terra configs receive `sdkVersion: 4.2.7.143`
- `git diff --check`