### PR TITLE
fix(ci): allow Electron Windows packages in CodeSign

### DIFF
--- a/ci/build/build_windows.groovy
+++ b/ci/build/build_windows.groovy
@@ -61,6 +61,7 @@ def doPublish(buildVariables) {
     }
     def codesignResult = build(job: 'CodeSign', parameters: [
         text(name: 'PACKAGE_URLS', value: codesignUrls.join('\n')),
+        string(name: 'SIGN_PACKAGE_WHITELIST', value: '*_windows_*.zip'),
         string(name: 'SIGN_FILE_WHITELIST', value: '*.node'),
     ], propagate: false)
     if (!codesignResult || codesignResult.result != 'SUCCESS') {


### PR DESCRIPTION
## Summary

Allow Electron Windows CDN archives through the existing CodeSign package whitelist on `special/4.2`.

## Failure

CDN release build #783 failed in Windows ia32 child `build_windows #1927`, because CodeSign #862 skipped the archive and reported:

`No PACKAGE_URLS entry matched SIGN_PACKAGE_WHITELIST and was processed.`

## Scope

One-line backport of the established Electron CodeSign fix: `SIGN_PACKAGE_WHITELIST=*_windows_*.zip`.

## Validation

- `git diff --check`
- Asserted the whitelist matches the failed ia32 archive basename
- Confirmed the failure uses released tag `v4.2.7-build.143-dev.1` at `e5a0758a`